### PR TITLE
Bugfix for <<Class 'RPC\RPC\Signal' not found>> issue in RPC\Signal

### DIFF
--- a/src/RPC/Signal.php
+++ b/src/RPC/Signal.php
@@ -144,14 +144,14 @@ class Signal
 				}
 				else
 				{
-					$ret = RPC\Signal::emit( $slot['slot'], $params );
+					$ret = \RPC\Signal::emit( $slot['slot'], $params );
 				}
 				
-				if( $ret === RPC\Signal::STOP_BROADCAST )
+				if( $ret === \RPC\Signal::STOP_BROADCAST )
 				{
 					break;
 				}
-				elseif( $ret === RPC\Signal::STOP_SIGNAL )
+				elseif( $ret === \RPC\Signal::STOP_SIGNAL )
 				{
 					return false;
 				}


### PR DESCRIPTION
Hey @eflorea, please merge this into master. Found this issue while working on CaReg V3. Thanks!