### PR TITLE
~ Skipped validator method logic if the "optional" key is encountered

### DIFF
--- a/src/RPC/Db/Table/Row.php
+++ b/src/RPC/Db/Table/Row.php
@@ -595,6 +595,12 @@ class Row implements ArrayAccess
 
 			foreach( $rules as $rule => $msg )
 			{
+				// skip over running a validation method if this rule is 'optional'
+				if( $rule == 'optional' )
+				{
+					continue;
+				}
+
 				//check if msg exists
 				if( is_numeric( $rule ) )
 				{


### PR DESCRIPTION
This PR allows for the `optional` key to be added to the validator rules.