### PR TITLE
Add CLI plain text error handler

### DIFF
--- a/src/RPC/init.php
+++ b/src/RPC/init.php
@@ -1,9 +1,9 @@
 <?php
 
 function RPC_Shutdown() { 
-	if( count( func_get_args() ) )
-	{
-    	echo 'Something went wrong. Our amazing team of developers have been notified. Please try again later.';
+    if( count( func_get_args() ) )
+    {
+        echo 'Something went wrong. Our amazing team of developers have been notified. Please try again later.';
     }
 }
 register_shutdown_function( 'RPC_Shutdown' );
@@ -16,21 +16,25 @@ ini_set( 'display_errors', 0 );
 
 if( getenv( "SHOW_ERRORS" ) === "true" )
 {
-	ini_set( 'display_errors', 1 );
-	$whoops = new \Whoops\Run;
-	$whoops->pushHandler(new \Whoops\Handler\PrettyPageHandler);
-	$whoops->register();
+    ini_set( 'display_errors', 1 );
+    $whoops = new \Whoops\Run;
+    if( strpos( php_sapi_name(), 'cli' ) === false ) {
+        $whoops->pushHandler(new \Whoops\Handler\PrettyPageHandler);
+    } else {
+        $whoops->pushHandler(new \Whoops\Handler\PlainTextHandler);
+    }
+    $whoops->register();
 }
 
 //set some default constants if they aren't defined
 if( ! defined( 'APP_PATH' ) )
 {
-	define( 'APP_PATH', ROOT_PATH . '/APP' );
+    define( 'APP_PATH', ROOT_PATH . '/APP' );
 }
 
 if( ! defined( 'CACHE_PATH' ) )
 {
-	define( 'CACHE_PATH', ROOT_PATH . '/tmp/cache' );
+    define( 'CACHE_PATH', ROOT_PATH . '/tmp/cache' );
 }
 
 


### PR DESCRIPTION
This will add a Whoops `PlainTextHandler` for errors when running scripts from the CLI. There are a few more changes in diff because It had inconsistent tabs/spaces so I converted all to spaces.