### PR TITLE
Add trailing space to manual_sql in datagrid to fix sql error

### DIFF
--- a/src/RPC/Datagrid.php
+++ b/src/RPC/Datagrid.php
@@ -304,7 +304,7 @@ class Datagrid
 		if( $this->manual_sql )
 		{
 			$sql = trim( $this->manual_sql );
-			$sql = preg_replace( '/select /', 'select SQL_CALC_FOUND_ROWS', $this->manual_sql, 1 );
+			$sql = preg_replace( '/select /', 'select SQL_CALC_FOUND_ROWS ', $this->manual_sql, 1 );
 		}
 		else
 		{


### PR DESCRIPTION
Added a space to the end of the preg_replace for manual queries to fix sql error.