### PR TITLE
- Datagrid manual sql bugfixes

### DIFF
--- a/src/RPC/Datagrid.php
+++ b/src/RPC/Datagrid.php
@@ -306,7 +306,7 @@ class Datagrid
 		if( $this->manual_sql )
 		{
 			$sql = trim( $this->manual_sql );
-			$sql = preg_replace( '/select /', 'select SQL_CALC_FOUND_ROWS ', $this->manual_sql, 1 );
+			$sql = preg_replace( '/select (?!SQL_CALC_FOUND_ROWS)/i', 'select SQL_CALC_FOUND_ROWS ', $this->manual_sql, 1 );
 		}
 		else
 		{


### PR DESCRIPTION
- Allow case insensitive preg_replace for Datagrid manual sql
- Make sure we don't duplicate the SQL_CALC_FOUND_ROWS keyword