### PR TITLE
PHP 7.2 bug fix for `count()` function

### DIFF
--- a/src/RPC/Db/Table/Adapter/MSSQL.php
+++ b/src/RPC/Db/Table/Adapter/MSSQL.php
@@ -161,12 +161,7 @@ class MSSQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		if( count( $res ) )
-		{
-			return $res[0];
-		}
-
-		return null;
+		return $res ? $res[0] : null;
 	}
 
 
@@ -178,12 +173,8 @@ class MSSQL extends Adapter
 		{
 			$sql = 'select top 1000 * from "' . $this->getName() . '"';
 			$res = $this->getDb()->query( $sql );
-			if( count( $res ) )
-			{
-				return $res;
-			}
 			
-			return null;
+			return $res ?: [];
 		}
 
 		$condition_values = array();
@@ -237,12 +228,7 @@ class MSSQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		if( count( $res ) )
-		{
-			return $res;
-		}
-
-		return null;
+		return $res ?: [];
 	}
 
 
@@ -306,12 +292,7 @@ class MSSQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		if( count( $res ) )
-		{
-			return $res;
-		}
-
-		return null;
+		return $res ?: [];
 	}
 
 
@@ -377,7 +358,7 @@ class MSSQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		if( count( $res ) )
+		if( $res )
 		{
 			$row = $res[0];
 
@@ -466,7 +447,7 @@ class MSSQL extends Adapter
 
 
 
-		if( count( $res ) )
+		if( $res )
 		{
 			$fields = $this->getFields();
 
@@ -493,7 +474,7 @@ class MSSQL extends Adapter
 			return $output;
 		}
 
-		return null;
+		return [];
 	}
 
 	public function findBySql()
@@ -558,7 +539,7 @@ class MSSQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		if( count( $res ) )
+		if( $res )
 		{
 			$output = array();
 
@@ -583,7 +564,7 @@ class MSSQL extends Adapter
 			return $output;
 		}
 
-		return null;
+		return [];
 	}
 
 

--- a/src/RPC/Db/Table/Adapter/MSSQL.php
+++ b/src/RPC/Db/Table/Adapter/MSSQL.php
@@ -107,7 +107,7 @@ class MSSQL extends Adapter
 
 		if( ! isset( $args[0] ) )
 		{
-			return null;
+			return [];
 		}
 
 		$condition_values = array();
@@ -161,7 +161,7 @@ class MSSQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		return $res ? $res[0] : null;
+		return $res ? $res[0] : [];
 	}
 
 

--- a/src/RPC/Db/Table/Adapter/MySQL.php
+++ b/src/RPC/Db/Table/Adapter/MySQL.php
@@ -108,7 +108,7 @@ class MySQL extends Adapter
 
 		if( ! isset( $args[0] ) )
 		{
-			return null;
+			return [];
 		}
 
 		$condition_values = array();
@@ -162,7 +162,7 @@ class MySQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		return $res ? $res[0] : null;
+		return $res ? $res[0] : [];
 	}
 
 

--- a/src/RPC/Db/Table/Adapter/MySQL.php
+++ b/src/RPC/Db/Table/Adapter/MySQL.php
@@ -162,12 +162,7 @@ class MySQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		if( count( $res ) )
-		{
-			return $res[0];
-		}
-
-		return null;
+		return $res ? $res[0] : null;
 	}
 
 
@@ -179,12 +174,8 @@ class MySQL extends Adapter
 		{
 			$sql = "select * from `" . $this->getName() . "` limit 1000";
 			$res = $this->getDb()->query( $sql );
-			if( count( $res ) )
-			{
-				return $res;
-			}
 			
-			return null;
+			return $res ?: [];
 		}
 
 		$condition_values = array();
@@ -238,12 +229,7 @@ class MySQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		if( count( $res ) )
-		{
-			return $res;
-		}
-
-		return null;
+		return $res ?: [];
 	}
 
 
@@ -307,12 +293,7 @@ class MySQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		if( count( $res ) )
-		{
-			return $res;
-		}
-
-		return null;
+		return $res ?: [];
 	}
 
 
@@ -378,7 +359,7 @@ class MySQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		if( count( $res ) )
+		if( $res )
 		{
 			$row = $res[0];
 
@@ -467,7 +448,7 @@ class MySQL extends Adapter
 
 
 
-		if( count( $res ) )
+		if( $res )
 		{
 			$fields = $this->getFields();
 
@@ -494,7 +475,7 @@ class MySQL extends Adapter
 			return $output;
 		}
 
-		return null;
+		return [];
 	}
 
 	public function findBySql()
@@ -559,7 +540,7 @@ class MySQL extends Adapter
 			$res = $this->getDb()->query( $sql );
 		}
 
-		if( count( $res ) )
+		if( $res )
 		{
 			$output = array();
 
@@ -584,7 +565,7 @@ class MySQL extends Adapter
 			return $output;
 		}
 
-		return null;
+		return [];
 	}
 
 


### PR DESCRIPTION
Return an empty array by default instead of `null` when we're quering the database and expect an array of entries in result. See:
http://php.net/manual/en/function.count.php#refsect1-function.count-changelog